### PR TITLE
feat(metadata): add support for id3 tag input+ output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun
+        with:
+          bun-version: latest@v1
 
       - name: Install ffmpeg
         run: sudo apt-get update && sudo apt-get install -y ffmpeg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun
+      - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest@v1
+          bun-version: latest
 
       - name: Install ffmpeg
         run: sudo apt-get update && sudo apt-get install -y ffmpeg

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -54,6 +54,7 @@
     "acodec",
     "antfu",
     "commitlint",
-    "ffprobe"
+    "ffprobe",
+    "Lavf"
   ]
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,7 @@
 import antfu from '@antfu/eslint-config'
 
-export default antfu()
+export default antfu({
+  rules: {
+    '@typescript-eslint/no-non-null-asserted-optional-chain': 0,
+  },
+})

--- a/src/audio-args.ts
+++ b/src/audio-args.ts
@@ -5,7 +5,7 @@ export function audioArgs(options?: FfmpegAudioOptions) {
     return []
   }
 
-  const { codec, bitrate, channels, sampleRate, quality } = options
+  const { codec, bitrate, channels, sampleRate, quality, metadata } = options
 
   return [
     ...(codec ? ['-acodec', codec] : []),
@@ -13,5 +13,6 @@ export function audioArgs(options?: FfmpegAudioOptions) {
     ...(channels ? ['-ac', channels.toString()] : []),
     ...(sampleRate ? ['-ar', sampleRate.toString()] : []),
     ...(quality ? ['-q:a', quality.toString()] : []),
+    ...(metadata ? Object.entries(metadata).flatMap(([key, value]) => ['-metadata', `${key}=${value}`]) : []),
   ]
 }

--- a/src/audio.test.ts
+++ b/src/audio.test.ts
@@ -4,8 +4,10 @@ import { audio, audioWav, audioWithStreamInput, audioWithStreamInputAndOut, audi
 import { audioInfo } from './audio-info'
 
 const input = `${import.meta.dir}/samples/input.mp3`
-const output = `${import.meta.dir}/samples/output.wav`
-const outputMp3 = `${import.meta.dir}/samples/output.mp3`
+const output = {
+  wav: `${import.meta.dir}/samples/output.wav`,
+  mp3: `${import.meta.dir}/samples/output.mp3`,
+}
 
 describe('audio', () => {
   it('should throw an error if the input is not a correct path', async () => {
@@ -24,16 +26,16 @@ describe('audio', () => {
   })
 
   it('audio: normal test ', async () => {
-    await audio(input, output, {
+    await audio(input, output.wav, {
       codec: 'pcm_s16le',
       channels: 1,
       sampleRate: 16000,
       bitrate: '160k',
     })
 
-    expect(await Bun.file(output).exists()).toBeTrue()
+    expect(await Bun.file(output.wav).exists()).toBeTrue()
 
-    const result = await audioInfo(output)
+    const result = await audioInfo(output.wav)
 
     expect(result).toEqual([
       {
@@ -45,11 +47,11 @@ describe('audio', () => {
       },
     ])
 
-    await unlink(output)
+    await unlink(output.wav)
   })
 
   it('audio: normal test with id3 metadata', async () => {
-    await audio(input, outputMp3, {
+    await audio(input, output.mp3, {
       codec: 'mp3',
       bitrate: '192k',
       channels: 2,
@@ -66,9 +68,9 @@ describe('audio', () => {
       },
     })
 
-    expect(await Bun.file(outputMp3).exists()).toBeTrue()
+    expect(await Bun.file(output.mp3).exists()).toBeTrue()
 
-    const result = await audioInfo(outputMp3, {
+    const result = await audioInfo(output.mp3, {
       metadataTags: ['title', 'artist', 'album', 'track', 'genre', 'composer', 'comment', 'year', 'encoder'],
     })
 
@@ -93,23 +95,23 @@ describe('audio', () => {
       },
     ])
 
-    await unlink(outputMp3)
+    await unlink(output.mp3)
   })
 
   it('audioWithStreamInput: normal test ', async () => {
     const file = Bun.file(input)
     const stream = file.stream()
 
-    await audioWithStreamInput(stream, output, {
+    await audioWithStreamInput(stream, output.wav, {
       codec: 'pcm_s16le',
       bitrate: '128k',
       channels: 1,
       sampleRate: 16000,
     })
 
-    expect(await Bun.file(output).exists()).toBeTrue()
+    expect(await Bun.file(output.wav).exists()).toBeTrue()
 
-    await unlink(output)
+    await unlink(output.wav)
   })
 
   it('audioWithStreamOut: normal test ', async () => {
@@ -119,7 +121,7 @@ describe('audio', () => {
         {
           onProcessDataFlushed: () => {},
           onProcessDataEnd: async (data) => {
-            await Bun.write(output, data!)
+            await Bun.write(output.wav, data!)
             resolve()
           },
         },
@@ -134,9 +136,9 @@ describe('audio', () => {
 
     await fileWritePromise
 
-    expect(await Bun.file(output).exists()).toBeTrue()
+    expect(await Bun.file(output.wav).exists()).toBeTrue()
 
-    const result = await audioInfo(output)
+    const result = await audioInfo(output.wav)
     expect(result).toEqual([
       {
         codec: 'pcm_s16le',
@@ -147,7 +149,7 @@ describe('audio', () => {
       },
     ])
 
-    await unlink(output)
+    await unlink(output.wav)
   })
 
   it('audioWithStreamInputAndOut: normal test', async () => {
@@ -160,7 +162,7 @@ describe('audio', () => {
         {
           onProcessDataFlushed: () => {},
           onProcessDataEnd: async (data) => {
-            await Bun.write(output, data!)
+            await Bun.write(output.wav, data!)
             resolve()
           },
         },
@@ -175,9 +177,9 @@ describe('audio', () => {
 
     await fileWritePromise
 
-    expect(await Bun.file(output).exists()).toBeTrue()
+    expect(await Bun.file(output.wav).exists()).toBeTrue()
 
-    const result = await audioInfo(output)
+    const result = await audioInfo(output.wav)
     expect(result).toEqual([
       {
         codec: 'pcm_s16le',
@@ -188,7 +190,7 @@ describe('audio', () => {
       },
     ])
 
-    await unlink(output)
+    await unlink(output.wav)
   })
 
   it('audioWithStreamInputAndOut: chunks', async () => {
@@ -219,7 +221,7 @@ describe('audio', () => {
         {
           onProcessDataFlushed: () => {},
           onProcessDataEnd: async (data) => {
-            await Bun.write(output, data!)
+            await Bun.write(output.wav, data!)
             resolve()
           },
         },
@@ -234,9 +236,9 @@ describe('audio', () => {
 
     await fileWritePromise
 
-    expect(await Bun.file(output).exists()).toBeTrue()
+    expect(await Bun.file(output.wav).exists()).toBeTrue()
 
-    const result = await audioInfo(output)
+    const result = await audioInfo(output.wav)
     expect(result).toEqual([
       {
         codec: 'pcm_s16le',
@@ -247,16 +249,16 @@ describe('audio', () => {
       },
     ])
 
-    await unlink(output)
+    await unlink(output.wav)
   })
 
   it('audioBuffer', async () => {
     const arrayBuffer = await Bun.file(input).arrayBuffer()
     const data = await audioWav(new Uint8Array(arrayBuffer))
-    await Bun.write(output, data!)
-    expect(await Bun.file(output).exists()).toBeTrue()
+    await Bun.write(output.wav, data!)
+    expect(await Bun.file(output.wav).exists()).toBeTrue()
 
-    const result = await audioInfo(output)
+    const result = await audioInfo(output.wav)
     expect(result).toEqual([
       {
         codec: 'pcm_s16le',
@@ -267,6 +269,6 @@ describe('audio', () => {
       },
     ])
 
-    await unlink(output)
+    await unlink(output.wav)
   })
 })

--- a/src/audio.test.ts
+++ b/src/audio.test.ts
@@ -71,7 +71,7 @@ describe('audio', () => {
     expect(await Bun.file(output.mp3).exists()).toBeTrue()
 
     const result = await audioInfo(output.mp3, {
-      metadataTags: ['title', 'artist', 'album', 'track', 'genre', 'composer', 'comment', 'year', 'encoder'],
+      metadataTags: ['title', 'artist', 'album', 'track', 'genre', 'composer', 'comment', 'year'],
     })
 
     expect(result).toEqual([
@@ -90,7 +90,6 @@ describe('audio', () => {
           composer: 'track composer',
           comment: 'track comment',
           year: '2024',
-          encoder: 'Lavf61.1.100',
         },
       },
     ])

--- a/src/audio.test.ts
+++ b/src/audio.test.ts
@@ -74,7 +74,7 @@ describe('audio', () => {
       metadataTags: ['title', 'artist', 'album', 'track', 'genre', 'composer', 'comment', 'year', 'encoder'],
     })
 
-    expect(result).toEqual([
+    expect(result).toMatchObject([
       {
         codec: 'mp3',
         channels: 2,
@@ -90,10 +90,13 @@ describe('audio', () => {
           composer: 'track composer',
           comment: 'track comment',
           year: '2024',
-          encoder: 'Lavf61.1.100',
         },
       },
     ])
+
+    // This could be different in different environments
+    // eslint-disable-next-line dot-notation
+    expect(result[0].metadata?.['encoder']!).toMatch(/Lavf\d+\.\d+\.\d+/)
 
     await unlink(output.mp3)
   })

--- a/src/audio.test.ts
+++ b/src/audio.test.ts
@@ -5,6 +5,7 @@ import { audioInfo } from './audio-info'
 
 const input = `${import.meta.dir}/samples/input.mp3`
 const output = `${import.meta.dir}/samples/output.wav`
+const outputMp3 = `${import.meta.dir}/samples/output.mp3`
 
 describe('audio', () => {
   it('should throw an error if the input is not a correct path', async () => {
@@ -45,6 +46,54 @@ describe('audio', () => {
     ])
 
     await unlink(output)
+  })
+
+  it('audio: normal test with id3 metadata', async () => {
+    await audio(input, outputMp3, {
+      codec: 'mp3',
+      bitrate: '192k',
+      channels: 2,
+      sampleRate: 44100,
+      metadata: {
+        title: 'track title',
+        artist: 'track artist',
+        album: 'track album',
+        comment: 'track comment',
+        genre: 'track genre',
+        year: '2024',
+        track: '1',
+        composer: 'track composer',
+      },
+    })
+
+    expect(await Bun.file(outputMp3).exists()).toBeTrue()
+
+    const result = await audioInfo(outputMp3, {
+      metadataTags: ['title', 'artist', 'album', 'track', 'genre', 'composer', 'comment', 'year', 'encoder'],
+    })
+
+    expect(result).toEqual([
+      {
+        codec: 'mp3',
+        channels: 2,
+        sampleRate: '44100',
+        bitrate: '192000',
+        duration: '12.355918',
+        metadata: {
+          title: 'track title',
+          artist: 'track artist',
+          album: 'track album',
+          track: '1',
+          genre: 'track genre',
+          composer: 'track composer',
+          comment: 'track comment',
+          year: '2024',
+          encoder: 'Lavf61.1.100',
+        },
+      },
+    ])
+
+    await unlink(outputMp3)
   })
 
   it('audioWithStreamInput: normal test ', async () => {

--- a/src/audio.test.ts
+++ b/src/audio.test.ts
@@ -71,7 +71,7 @@ describe('audio', () => {
     expect(await Bun.file(output.mp3).exists()).toBeTrue()
 
     const result = await audioInfo(output.mp3, {
-      metadataTags: ['title', 'artist', 'album', 'track', 'genre', 'composer', 'comment', 'year'],
+      metadataTags: ['title', 'artist', 'album', 'track', 'genre', 'composer', 'comment', 'year', 'encoder'],
     })
 
     expect(result).toMatchObject([

--- a/src/types/audio.ts
+++ b/src/types/audio.ts
@@ -8,6 +8,9 @@ export interface FfmpegAudioOptions {
   channels?: 1 | 2 | 5.1 | 7.1 | number
   sampleRate?: 8000 | 16000 | 44100 | 48000 | number
   quality?: number
+  metadata?: {
+    [key: string]: string
+  }
   onError?: (error: unknown) => void
 }
 
@@ -22,4 +25,21 @@ export interface FfmpegAudioInfo {
   channels: number
   sampleRate: string
   duration: string
+  metadata?: {
+    title?: string
+    artist?: string
+    album?: string
+    track?: string
+    date?: string
+    genre?: string
+    composer?: string
+    comment?: string
+    year?: string
+    encoder?: string
+    [key: string]: string | undefined
+  }
+}
+
+export interface AudioInfoOptions {
+  metadataTags?: string[]
 }

--- a/src/types/audio.ts
+++ b/src/types/audio.ts
@@ -26,17 +26,7 @@ export interface FfmpegAudioInfo {
   sampleRate: string
   duration: string
   metadata?: {
-    title?: string
-    artist?: string
-    album?: string
-    track?: string
-    date?: string
-    genre?: string
-    composer?: string
-    comment?: string
-    year?: string
-    encoder?: string
-    [key: string]: string | undefined
+    [key: string]: string
   }
 }
 


### PR DESCRIPTION
## Description

This PR adds the ability to input ID3 metadata tags to the encoder input and ffprobe based `audioInfo` output. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes

## Related issues

- N/A

## Additional context

- Added unit test for ID3 tag support (mp3 encoding) in [./src/audio.test.ts](./src/audio.test.ts)
- No breaking changes
- Tried my best to adhere to the existing code style/formatting. Please request changes if there's anything I can do to better adhere to your style. 
- Did not add any comments to my code, if there's anything that needs clarification, please let me know. 
- Did not modify documentation, unsure if this is desired but happy to do so if that's the case. 


